### PR TITLE
fix: change endpoint to graphql endpoint and use chainlit url as env param

### DIFF
--- a/python-client/chainlit_client/api.py
+++ b/python-client/chainlit_client/api.py
@@ -140,13 +140,15 @@ def query_builder(steps):
 
 
 class API:
-    def __init__(self, api_key=None, endpoint=None):
+    def __init__(self, api_key=None, url=None):
         self.api_key = api_key
-        self.endpoint = endpoint
+        self.url = url
+        self.graphql_endpoint = url + "/api/graphql"
+
         if self.api_key is None:
             raise Exception("CHAINLIT_API_KEY not set")
-        if self.endpoint is None:
-            raise Exception("CHAINLIT_ENDPOINT not set")
+        if self.url is None:
+            raise Exception("CHAINLIT_API_URL not set")
 
     @property
     def headers(self):
@@ -165,7 +167,7 @@ class API:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(
-                    self.endpoint,
+                    self.graphql_endpoint,
                     json={"query": query, "variables": variables},
                     headers=self.headers,
                     timeout=10,
@@ -941,7 +943,7 @@ class API:
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.endpoint}{path}",
+                f"{self.url}{path}",
                 json=body,
                 headers=self.headers,
             )

--- a/python-client/chainlit_client/client.py
+++ b/python-client/chainlit_client/client.py
@@ -22,18 +22,16 @@ class ChainlitClient:
         self,
         batch_size: int = 1,
         api_key: Optional[str] = None,
-        endpoint: Optional[str] = None,
+        url: Optional[str] = None,
     ):
         if not api_key:
             api_key = os.getenv("CHAINLIT_API_KEY", None)
             if not api_key:
                 raise Exception("CHAINLIT_API_KEY not provided")
-        if not endpoint:
-            endpoint = os.getenv(
-                "CHAINLIT_ENDPOINT", "https://cloud.chainlit.io/graphql"
-            )
+        if not url:
+            url = os.getenv("CHAINLIT_API_URL", "https://cloud.chainlit.io")
 
-        self.api = API(api_key=api_key, endpoint=endpoint)
+        self.api = API(api_key=api_key, url=url)
         self.event_processor = EventProcessor(
             api=self.api,
             batch_size=batch_size,

--- a/python-client/examples/.env.example
+++ b/python-client/examples/.env.example
@@ -1,4 +1,4 @@
 OPENAI_API_KEY=sk-
 
 CHAINLIT_API_KEY="cl_"
-CHAINLIT_ENDPOINT="http://localhost:3000/api/graphql"
+CHAINLIT_API_URL="http://localhost:3000"


### PR DESCRIPTION
There was a confusion between the graphql endpoints and the api endpoint (used for file upload)

This PR fixes this

I renamed the `CHAINLIT_ENDPOINT` env var to `CHAINLIT_URL`  which now must be `http://localhost:3000` for local 