### PR TITLE
Fix thread id duplicated

### DIFF
--- a/examples/parallel_requests.py
+++ b/examples/parallel_requests.py
@@ -1,0 +1,38 @@
+import asyncio
+from dotenv import load_dotenv
+from literalai import LiteralClient
+
+load_dotenv()
+
+client = LiteralClient()
+
+
+@client.thread
+def request(query):
+    client.message(query)
+    return query
+
+
+@client.thread
+async def async_request(query, sleepy):
+    client.message(query)
+    await asyncio.sleep(sleepy)
+    return query
+
+
+@client.thread(thread_id="e3fcf535-2555-4f75-bc10-fc1499baeff4")
+def precise_request(query):
+    client.message(query)
+    return query
+
+
+async def main():
+    request("hello")
+    request("world!")
+    precise_request("bonjour!")
+
+    await asyncio.gather(async_request("foo", 5), async_request("bar", 2))
+
+
+asyncio.run(main())
+client.wait_until_queue_empty()

--- a/literalai/thread.py
+++ b/literalai/thread.py
@@ -84,8 +84,6 @@ class ThreadContextManager:
         **kwargs,
     ):
         self.client = client
-        if thread_id is None:
-            thread_id = str(uuid.uuid4())
         self.thread_id = thread_id
         self.kwargs = kwargs
 
@@ -107,7 +105,8 @@ class ThreadContextManager:
         return thread_decorator(self.client, func=func, ctx_manager=self)
 
     def __enter__(self) -> "Optional[Thread]":
-        active_thread_var.set(Thread(id=self.thread_id, **self.kwargs))
+        thread_id = self.thread_id if self.thread_id else str(uuid.uuid4())
+        active_thread_var.set(Thread(id=thread_id, **self.kwargs))
         return active_thread_var.get()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -119,7 +118,8 @@ class ThreadContextManager:
         active_thread_var.set(None)
 
     async def __aenter__(self):
-        active_thread_var.set(Thread(id=self.thread_id, **self.kwargs))
+        thread_id = self.thread_id if self.thread_id else str(uuid.uuid4())
+        active_thread_var.set(Thread(id=thread_id, **self.kwargs))
         return active_thread_var.get()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -320,3 +320,23 @@ class Teste2e:
 
         thread_id, step_id = await a_thread_decorated()
         await assert_delete(thread_id, step_id)
+
+    async def test_parallel_requests(self, client: LiteralClient):
+        ids = []
+
+        @client.thread
+        def request():
+            t = client.get_current_thread()
+            ids.append(t.id)
+
+        @client.thread
+        async def async_request():
+            t = client.get_current_thread()
+            ids.append(t.id)
+
+        request()
+        request()
+        await async_request()
+        await async_request()
+
+        assert len(ids) == len(set(ids))


### PR DESCRIPTION
## Changes

- If thread id is dynamic, generate the id on call

## How to test?

- `python examples/concurrent_test.py`