### PR TITLE
fix: make params optional

### DIFF
--- a/literalai/api/__init__.py
+++ b/literalai/api/__init__.py
@@ -2171,23 +2171,13 @@ class AsyncLiteralAPI(BaseLiteralAPI):
         prompt_id: Optional[str] = None,
         params: Optional[Dict] = None,
     ) -> "DatasetExperiment":
-        """
-        Asynchronously creates an experiment within a dataset.
-
-        Args:
-            dataset_id (str): The unique identifier of the dataset.
-            name (str): The name of the experiment.
-            prompt_id (Optional[str]): The identifier of the prompt associated with the experiment.
-            params (Optional[Dict]): Additional parameters for the experiment.
-
-        Returns:
-            DatasetExperiment: The created experiment object.
-        """
         sync_api = LiteralAPI(self.api_key, self.url)
 
         return await self.gql_helper(
             *create_experiment_helper(sync_api, dataset_id, name, prompt_id, params)
         )
+    
+    create_experiment.__doc__ = LiteralAPI.create_experiment.__doc__
 
     async def create_experiment_item(
         self, experiment_item: DatasetExperimentItem

--- a/literalai/api/gql.py
+++ b/literalai/api/gql.py
@@ -798,7 +798,7 @@ CREATE_EXPERIMENT = """
         $name: String! 
         $datasetId: String!
         $promptId: String
-        $params: Json!
+        $params: Json
     ) {
         createDatasetExperiment(
             name: $name

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -596,3 +596,12 @@ is a templated list."""
         )
 
         assert new_prompt.id == prompt.id, "Existing prompt should be returned"
+
+    @pytest.mark.timeout(5)
+    async def test_experiment_params_optional(self, client: LiteralClient):
+        dataset = client.api.create_dataset(
+            name="test-dataset", description="test-description"
+        )
+        experiment = dataset.create_experiment(name="test-experiment")
+        assert experiment.params is None
+        dataset.delete()


### PR DESCRIPTION
`Dataset.create_experiment` had `params` mandatory at the GraphQL level.

I changed it to be optional.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/python-client/66)
<!-- Reviewable:end -->
