### PR TITLE
Python SDK - fix: use promptType and switch llm steps to be run

### DIFF
--- a/literalai/api/generation_helpers.py
+++ b/literalai/api/generation_helpers.py
@@ -49,12 +49,7 @@ def create_generation_helper(generation: Union[ChatGeneration, CompletionGenerat
     variables = {"generation": generation.to_dict()}
 
     def process_response(response):
-        generation_as_step = response["data"]["createGeneration"]
-        deprecated_generation = {
-            "id": generation_as_step["id"],
-            "type": generation_as_step["promptType"],
-        }
-        return BaseGeneration.from_dict(deprecated_generation)
+        return BaseGeneration.from_dict(response["data"]["createGeneration"])
 
     description = "create generation"
 

--- a/literalai/api/gql.py
+++ b/literalai/api/gql.py
@@ -767,7 +767,7 @@ CREATE_GENERATION = """
 mutation CreateGeneration($generation: GenerationPayloadInput!) {
     createGeneration(generation: $generation) {
         id
-        promptType
+        type
     }
 }
 """


### PR DESCRIPTION
Fixes for the migration:
- handle the `promptType` to remap it to a `type`
- replace `llm` to `run` since we need to pass either `messages` or `prompt` for LLM steps

End-to-end tests should pass against the migration branch.