### PR TITLE
fix: prompt variable + langchain agent steps

### DIFF
--- a/literalai/prompt.py
+++ b/literalai/prompt.py
@@ -214,9 +214,11 @@ class Prompt(Utils):
                     additonal_kwargs = {}
                     if self.orig_messages and index < len(self.orig_messages):
                         additonal_kwargs = {
-                            "uuid": self.orig_messages[index].get("uuid")
-                            if self.orig_messages
-                            else None,
+                            "uuid": (
+                                self.orig_messages[index].get("uuid")
+                                if self.orig_messages
+                                else None
+                            ),
                             "prompt_id": self.prompt_id,
                             "variables": variables_with_defaults,
                         }
@@ -245,7 +247,7 @@ class Prompt(Utils):
         lc_messages = [(m["role"], m["content"]) for m in self.template_messages]
 
         chat_template = CustomChatPromptTemplate.from_messages(lc_messages)
-        chat_template.input_variables = []
+        chat_template.input_variables = ["agent_scratchpad"]
         chat_template.default_vars = self.variables_default_values
         chat_template.orig_messages = self.template_messages
         chat_template.prompt_id = self.id


### PR DESCRIPTION
![image](https://github.com/Chainlit/python-client/assets/6545903/c9a4cf7c-bb60-4d9e-9503-e665dc88b5a7)

### **To test:**
Start by creating a prompt template with name "LC Agent" from within Literal with the following messages:
- system `You are a helpful assistant`
- assistant `{{chat_history}}`
- user `{{input}}`
- assistant `{{agent_scratchpad}}`

### **Run the following:**
```
# Set env vars:
# OPENAI_API_KEY
# TAVILY_API_KEY
# LITERAL_API_KEY
# LITERAL_API_URL

import os
import getpass

from literalai import LiteralClient

from langchain_openai import ChatOpenAI
from langchain_community.tools.tavily_search import TavilySearchResults

model = ChatOpenAI(model="gpt-4o")
search = TavilySearchResults(max_results=2)
tools = [search]

lai_client = LiteralClient(api_key=os.environ["LITERAL_API_KEY"], url=os.environ["LITERAL_API_URL"])
lai_prompt = lai_client.api.get_prompt(name="LC Agent")
prompt = lai_prompt.to_langchain_chat_prompt_template()


from langchain.agents import create_tool_calling_agent
from langchain.agents import AgentExecutor

agent = create_tool_calling_agent(model, tools, prompt)
agent_executor = AgentExecutor(agent=agent, tools=tools)

lai_client.reset_context()
cb = lai_client.langchain_callback()

from langchain_core.messages import AIMessage, HumanMessage
from langchain_core.runnables.config import RunnableConfig

agent_executor.invoke({
    "chat_history": [
            # You can specify the intermediary messages as tuples too.
            # ("human", "hi! my name is bob"),
            # ("ai", "Hello Bob! How can I assist you today?")
            HumanMessage(content="hi! my name is bob"),
            AIMessage(content="Hello Bob! How can I assist you today?"),
        ],
    "input": "whats the weather in sf?"
}, config=RunnableConfig(callbacks=[cb], run_name="Weather SF"))
```