### PR TITLE
fix: conditionnally add BaseMessage id

### DIFF
--- a/literalai/my_types.py
+++ b/literalai/my_types.py
@@ -139,7 +139,7 @@ class BaseGeneration(Utils):
             raise ValueError(f"Unknown generation type: {type}")
 
     def to_dict(self):
-        return {
+        _dict = {
             "promptId": self.prompt_id,
             "provider": self.provider,
             "model": self.model,
@@ -155,6 +155,9 @@ class BaseGeneration(Utils):
             "tokenThroughputInSeconds": self.token_throughput_in_s,
             "duration": self.duration,
         }
+        if self.id:
+            _dict["id"] = self.id
+        return _dict
 
 
 @dataclass(repr=False)


### PR DESCRIPTION
Fixing the error: 

```
Exception: Failed to create generation: {"errors":[{"message":"Variable \"$generation\" got invalid value { id: null, promptId: null, provider: \"test\", model: \"test\", error: null, settings: {}, variables: {}, tags: [\"test\"], tools: null, tokenCount: null, inputTokenCount: null, outputTokenCount: null, ttFirstToken: null, tokenThroughputInSeconds: null, duration: null, messages: [{ role: \"user\", content: \"Hello\" }, { role: \"assistant\", content: \"Hi\" }], messageCompletion: { role: \"assistant\", content: \"Hello back!\" }, type: \"CHAT\" }; Field \"id\" is not defined by type \"GenerationPayloadInput\".","locations":[{"line":2,"column":27}],"extensions":{"code":"UNEXPECTED"}}]}

../../miniconda3/envs/tmp-py-client/lib/python3.9/site-packages/literalai/api/__init__.py:1371: Exception
```