### PR TITLE
feat: update sdks to send the root run

### DIFF
--- a/literalai/api/__init__.py
+++ b/literalai/api/__init__.py
@@ -10,14 +10,18 @@ from typing import (
     Literal,
     Optional,
     TypeVar,
-    Union, cast,
+    Union,
+    cast,
 )
 
 from typing_extensions import deprecated
 
 from literalai.context import active_steps_var, active_thread_var
 from literalai.evaluation.dataset import Dataset, DatasetType
-from literalai.evaluation.dataset_experiment import DatasetExperiment, DatasetExperimentItem
+from literalai.evaluation.dataset_experiment import (
+    DatasetExperiment,
+    DatasetExperimentItem,
+)
 from literalai.observability.filter import (
     generations_filters,
     generations_order_by,
@@ -51,7 +55,10 @@ from literalai.api.dataset_helpers import (
     get_dataset_item_helper,
     update_dataset_helper,
 )
-from literalai.api.generation_helpers import create_generation_helper, get_generations_helper
+from literalai.api.generation_helpers import (
+    create_generation_helper,
+    get_generations_helper,
+)
 from literalai.api.prompt_helpers import (
     create_prompt_helper,
     create_prompt_lineage_helper,
@@ -101,8 +108,20 @@ from literalai.my_types import (
     Environment,
     PaginatedResponse,
 )
-from literalai.observability.generation import GenerationMessage, CompletionGeneration, ChatGeneration
-from literalai.observability.step import Step, StepDict, StepType, ScoreType, ScoreDict, Score, Attachment
+from literalai.observability.generation import (
+    GenerationMessage,
+    CompletionGeneration,
+    ChatGeneration,
+)
+from literalai.observability.step import (
+    Step,
+    StepDict,
+    StepType,
+    ScoreType,
+    ScoreDict,
+    Score,
+    Attachment,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -678,8 +697,7 @@ class LiteralAPI(BaseLiteralAPI):
         fields: Dict = request_dict.get("fields", {})
         object_key: Optional[str] = fields.get("key")
         upload_type: Literal["raw", "multipart"] = cast(
-            Literal["raw", "multipart"],
-            request_dict.get("uploadType", "multipart")
+            Literal["raw", "multipart"], request_dict.get("uploadType", "multipart")
         )
         signed_url: Optional[str] = json_res.get("signedUrl")
 
@@ -843,6 +861,7 @@ class LiteralAPI(BaseLiteralAPI):
         parent_id: Optional[str] = None,
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        root_run_id: Optional[str] = None,
     ):
         """
         Creates a new step with the specified parameters.
@@ -858,6 +877,7 @@ class LiteralAPI(BaseLiteralAPI):
             parent_id (Optional[str]): The ID of the parent step, if any.
             name (Optional[str]): The name of the step.
             tags (Optional[List[str]]): Tags associated with the step.
+            root_run_id (Optional[str]): The ID of the root run, if any.
 
         Returns:
             The result of the GraphQL helper function for creating a step.
@@ -874,6 +894,7 @@ class LiteralAPI(BaseLiteralAPI):
                 parent_id=parent_id,
                 name=name,
                 tags=tags,
+                root_run_id=root_run_id,
             )
         )
 
@@ -1912,8 +1933,7 @@ class AsyncLiteralAPI(BaseLiteralAPI):
         fields: Dict = request_dict.get("fields", {})
         object_key: Optional[str] = fields.get("key")
         upload_type: Literal["raw", "multipart"] = cast(
-            Literal["raw", "multipart"],
-            request_dict.get("uploadType", "multipart")
+            Literal["raw", "multipart"], request_dict.get("uploadType", "multipart")
         )
         signed_url: Optional[str] = json_res.get("signedUrl")
 
@@ -2069,6 +2089,7 @@ class AsyncLiteralAPI(BaseLiteralAPI):
         parent_id: Optional[str] = None,
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        root_run_id: Optional[str] = None,
     ):
         """
         Asynchronously creates a new step with the specified parameters.
@@ -2084,6 +2105,7 @@ class AsyncLiteralAPI(BaseLiteralAPI):
             parent_id (Optional[str]): The ID of the parent step, if any.
             name (Optional[str]): The name of the step.
             tags (Optional[List[str]]): Tags associated with the step.
+            root_run_id (Optional[str]): The ID of the root run, if any.
 
         Returns:
             The result of the GraphQL helper function for creating a step.
@@ -2100,6 +2122,7 @@ class AsyncLiteralAPI(BaseLiteralAPI):
                 parent_id=parent_id,
                 name=name,
                 tags=tags,
+                root_run_id=root_run_id,
             )
         )
 

--- a/literalai/api/gql.py
+++ b/literalai/api/gql.py
@@ -6,6 +6,7 @@ from literalai.observability.step import Step, StepDict
 STEP_FIELDS = """
         id
         threadId
+        rootRunId
         parentId
         startTime
         endTime
@@ -559,6 +560,7 @@ CREATE_STEP = (
     """
 mutation CreateStep(
     $threadId: String,
+    $rootRunId: String,
     $type: StepType,
     $startTime: DateTime,
     $endTime: DateTime,
@@ -572,6 +574,7 @@ mutation CreateStep(
 ) {
     createStep(
         threadId: $threadId,
+        rootRunId: $rootRunId,
         type: $type,
         startTime: $startTime,
         endTime: $endTime,
@@ -878,12 +881,14 @@ mutation CreateDatasetItem(
     $input: Json!
     $expectedOutput: Json
     $metadata: Json
+    $generationId: String
 ) {
     createDatasetItem(
         datasetId: $datasetId
         input: $input
         expectedOutput: $expectedOutput
         metadata: $metadata
+        generationId: $generationId
     ) {
         id
         createdAt
@@ -892,6 +897,7 @@ mutation CreateDatasetItem(
         input
         expectedOutput
         intermediarySteps
+        stepId
     }
 }
 """
@@ -906,6 +912,7 @@ query GetDataItem($id: String!) {
         input
         expectedOutput
         intermediarySteps
+        stepId
     }
 }
 """
@@ -920,6 +927,7 @@ mutation DeleteDatasetItem($id: String!) {
         input
         expectedOutput
         intermediarySteps
+        stepId
     }
 }
 """
@@ -942,6 +950,7 @@ mutation AddStepToDataset(
         input
         expectedOutput
         intermediarySteps
+        stepId
     }
 }
 """
@@ -964,6 +973,7 @@ mutation AddGenerationToDataset(
         input
         expectedOutput
         intermediarySteps
+        stepId
     }
 }
 """
@@ -1080,6 +1090,7 @@ def steps_query_variables_builder(steps):
     for id in range(len(steps)):
         generated += f"""$id_{id}: String!
         $threadId_{id}: String
+        $rootRunId_{id}: String
         $type_{id}: StepType
         $startTime_{id}: DateTime
         $endTime_{id}: DateTime
@@ -1104,6 +1115,7 @@ def steps_ingest_steps_builder(steps):
       step{id}: ingestStep(
         id: $id_{id}
         threadId: $threadId_{id}
+        rootRunId: $rootRunId_{id}
         startTime: $startTime_{id}
         endTime: $endTime_{id}
         type: $type_{id}

--- a/literalai/api/step_helpers.py
+++ b/literalai/api/step_helpers.py
@@ -18,6 +18,7 @@ def create_step_helper(
     parent_id: Optional[str] = None,
     name: Optional[str] = None,
     tags: Optional[List[str]] = None,
+    root_run_id: Optional[str] = None,
 ):
     variables = {
         "threadId": thread_id,
@@ -30,6 +31,7 @@ def create_step_helper(
         "parentId": parent_id,
         "name": name,
         "tags": tags,
+        "root_run_id": root_run_id,
     }
 
     def process_response(response):

--- a/literalai/context.py
+++ b/literalai/context.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 active_steps_var = ContextVar[List["Step"]]("active_steps", default=[])
 active_thread_var = ContextVar[Optional["Thread"]]("active_thread", default=None)
+active_root_run_var = ContextVar[Optional["Step"]]("active_root_run_var", default=None)
 
 active_experiment_item_run_id_var = ContextVar[Optional[str]](
     "active_experiment_item_run", default=None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ mypy
 langchain
 llama-index
 pytest_httpx
-mistralai
+mistralai < 1.0.0


### PR DESCRIPTION
## Changes

- update gql query
- update client to receive the root run id
- update context to store the root run
- add tests to validate root run handling

## How to test?

- Start the local server on `clement/eng-1717-improve-ands-step-association`
- Start the `main.py` example 
- Notice the llm step has a `rootRunId` in db