### PR TITLE
LlamaIndex instrumentation

### DIFF
--- a/literalai/instrumentation/llamaindex/__init__.py
+++ b/literalai/instrumentation/llamaindex/__init__.py
@@ -1,0 +1,17 @@
+from literalai.client import LiteralClient
+from llama_index.core.instrumentation import get_dispatcher
+
+from literalai.instrumentation.llamaindex.event_handler import LiteralEventHandler
+from literalai.instrumentation.llamaindex.span_handler import LiteralSpanHandler
+
+
+def instrument_llamaindex(client: "LiteralClient"):
+    root_dispatcher = get_dispatcher()
+
+    span_handler = LiteralSpanHandler()
+    root_dispatcher.add_span_handler(span_handler)
+
+    event_handler = LiteralEventHandler(
+        literal_client=client, llama_index_span_handler=span_handler
+    )
+    root_dispatcher.add_event_handler(event_handler)

--- a/literalai/instrumentation/llamaindex/__init__.py
+++ b/literalai/instrumentation/llamaindex/__init__.py
@@ -4,8 +4,13 @@ from llama_index.core.instrumentation import get_dispatcher
 from literalai.instrumentation.llamaindex.event_handler import LiteralEventHandler
 from literalai.instrumentation.llamaindex.span_handler import LiteralSpanHandler
 
+is_llamaindex_instrumented = False
 
 def instrument_llamaindex(client: "LiteralClient"):
+    global is_llamaindex_instrumented
+    if is_llamaindex_instrumented:
+        return
+    
     root_dispatcher = get_dispatcher()
 
     span_handler = LiteralSpanHandler()
@@ -15,3 +20,5 @@ def instrument_llamaindex(client: "LiteralClient"):
         literal_client=client, llama_index_span_handler=span_handler
     )
     root_dispatcher.add_event_handler(event_handler)
+    
+    is_llamaindex_instrumented = True

--- a/literalai/instrumentation/llamaindex/span_handler.py
+++ b/literalai/instrumentation/llamaindex/span_handler.py
@@ -1,0 +1,182 @@
+from typing_extensions import TypedDict
+from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
+from llama_index.core.instrumentation.span import SimpleSpan
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from llama_index.core.tools import BaseTool, FunctionTool
+from llama_index.core.query_engine import RetrieverQueryEngine
+import uuid
+from literalai.context import active_thread_var
+
+literalai_uuid_namespace = uuid.UUID("05f6b2b5-a912-47bd-958f-98a9c4496322")
+
+
+def print_red(text: str):
+    print(f"\033[31m{text}\033[0m")
+
+
+class SpanEntry(TypedDict):
+    id: str
+    parent_id: Optional[str]
+    root_id: Optional[str]
+    is_run_root: bool
+
+
+class LiteralSpanHandler(BaseSpanHandler[SimpleSpan]):
+    """This class handles spans coming from LlamaIndex."""
+
+    spans: Dict[str, SpanEntry] = {}
+    tab_indent: int = 0
+    symbol: str = "  "
+
+    def __init__(self):
+        super().__init__()
+        self.tab_indent = 0
+        self.symbol = "  "
+
+    def new_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+        tags: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        tabs = self.symbol * self.tab_indent
+        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
+
+        self.spans[id_] = {
+            "id": id_,
+            "parent_id": parent_span_id,
+            "root_id": None,
+            "is_run_root": self.is_run_root(instance, parent_span_id),
+        }
+
+        if parent_span_id is not None:
+            self.spans[id_]["root_id"] = self.get_root_span_id(parent_span_id)
+        else:
+            self.spans[id_]["root_id"] = id_
+
+    def prepare_to_exit_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any,
+    ):
+        """Logic for preparing to exit a span."""
+        tabs = self.symbol * self.tab_indent
+        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
+        if id_ in self.spans:
+            del self.spans[id_]
+
+    def prepare_to_drop_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any,
+    ):
+        """Logic for preparing to drop a span."""
+        tabs = self.symbol * self.tab_indent
+        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
+        if id_ in self.spans:
+            del self.spans[id_]
+
+    def is_run_root(
+        self, instance: Optional[Any], parent_span_id: Optional[str]
+    ) -> bool:
+        """Returns True if the span is of type RetrieverQueryEngine, and it has no run root in its parent chain"""
+        if not isinstance(instance, RetrieverQueryEngine):
+            return False
+
+        # Span is of correct type, we check that it doesn't have a run root in its parent chain
+        while parent_span_id:
+            parent_span = self.spans.get(parent_span_id)
+
+            if not parent_span:
+                parent_span_id = None
+                continue
+
+            if parent_span["is_run_root"]:
+                return False
+
+            parent_span_id = parent_span["parent_id"]
+
+        return True
+
+    def get_root_span_id(self, span_id: Optional[str]):
+        """Finds the root span and returns its ID"""
+        if not span_id:
+            return None
+
+        current_span = self.spans.get(span_id)
+
+        if current_span is None:
+            return None
+
+        while current_span["parent_id"] is not None:
+            current_span = self.spans.get(current_span["parent_id"])
+            if current_span is None:
+                return None
+
+        return current_span["id"]
+
+    def get_run_id(self, span_id: Optional[str]):
+        """Go up the span chain to find a run_root, return its ID (or None)"""
+        if not span_id:
+            return None
+
+        current_span = self.spans.get(span_id)
+
+        if current_span is None:
+            return None
+
+        while current_span:
+            if current_span["is_run_root"]:
+                return str(uuid.uuid5(literalai_uuid_namespace, current_span["id"]))
+
+            parent_id = current_span["parent_id"]
+
+            if parent_id:
+                current_span = self.spans.get(parent_id)
+            else:
+                current_span = None
+
+        return None
+
+    def get_thread_id(self, span_id: Optional[str]):
+        """Returns the root span ID as a thread ID"""
+        active_thread = active_thread_var.get()
+
+        if active_thread:
+            return active_thread.id
+
+        if span_id is None:
+            return None
+
+        current_span = self.spans.get(span_id)
+
+        if current_span is None:
+            return None
+
+        root_id = current_span["root_id"]
+
+        if not root_id:
+            return None
+
+        root_span = self.spans.get(root_id)
+
+        if root_span is None:
+            # span is already the root, uuid its own id
+            return str(uuid.uuid5(literalai_uuid_namespace, span_id))
+        else:
+            # uuid the id of the root span
+            return str(uuid.uuid5(literalai_uuid_namespace, root_span["id"]))
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Class name."""
+        return "LiteralSpanHandler"

--- a/literalai/instrumentation/llamaindex/span_handler.py
+++ b/literalai/instrumentation/llamaindex/span_handler.py
@@ -8,6 +8,7 @@ from literalai.context import active_thread_var
 
 literalai_uuid_namespace = uuid.UUID("05f6b2b5-a912-47bd-958f-98a9c4496322")
 
+
 class SpanEntry(TypedDict):
     id: str
     parent_id: Optional[str]

--- a/literalai/instrumentation/llamaindex/span_handler.py
+++ b/literalai/instrumentation/llamaindex/span_handler.py
@@ -1,18 +1,12 @@
 from typing_extensions import TypedDict
 from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
 from llama_index.core.instrumentation.span import SimpleSpan
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
-from llama_index.core.tools import BaseTool, FunctionTool
+from typing import Any, Dict, Optional
 from llama_index.core.query_engine import RetrieverQueryEngine
 import uuid
 from literalai.context import active_thread_var
 
 literalai_uuid_namespace = uuid.UUID("05f6b2b5-a912-47bd-958f-98a9c4496322")
-
-
-def print_red(text: str):
-    print(f"\033[31m{text}\033[0m")
-
 
 class SpanEntry(TypedDict):
     id: str
@@ -25,13 +19,9 @@ class LiteralSpanHandler(BaseSpanHandler[SimpleSpan]):
     """This class handles spans coming from LlamaIndex."""
 
     spans: Dict[str, SpanEntry] = {}
-    tab_indent: int = 0
-    symbol: str = "  "
 
     def __init__(self):
         super().__init__()
-        self.tab_indent = 0
-        self.symbol = "  "
 
     def new_span(
         self,
@@ -42,9 +32,6 @@ class LiteralSpanHandler(BaseSpanHandler[SimpleSpan]):
         tags: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):
-        tabs = self.symbol * self.tab_indent
-        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
-
         self.spans[id_] = {
             "id": id_,
             "parent_id": parent_span_id,
@@ -66,8 +53,6 @@ class LiteralSpanHandler(BaseSpanHandler[SimpleSpan]):
         **kwargs: Any,
     ):
         """Logic for preparing to exit a span."""
-        tabs = self.symbol * self.tab_indent
-        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
         if id_ in self.spans:
             del self.spans[id_]
 
@@ -80,8 +65,6 @@ class LiteralSpanHandler(BaseSpanHandler[SimpleSpan]):
         **kwargs: Any,
     ):
         """Logic for preparing to drop a span."""
-        tabs = self.symbol * self.tab_indent
-        print_red(f"{tabs}{type(instance).__name__} #{id_[-6:]}")
         if id_ in self.spans:
             del self.spans[id_]
 


### PR DESCRIPTION
### Changes:
- added support to `llm.chat` and `llm.stream_chat`, `llm.predict`, `llm.predict_and_call`, `OpenAIAgent.chat` and `FunctionCallingAgent.chat`. 

### To test:
- validate that a call to the following methods creates a single `Generation`
  - `llm.chat`
  - `llm.stream_chat`
  - `llm.predict`

For the specific case of `llm.predict_and_call`, LlamaIndex does not fire an event for the tool calls that take place. Hence:
- either you decorate your tools with Literal AI step tools, in which case you should also wrap the call to `llm.predict_and_call` in a step or a thread (so that the tool steps have a parent, they cannot be standalone)
- or you do not decorate the tools and the `llm.predict_and_call` simply shows a `Generation` log

Ticket for LlamaIndex to add `ToolCallStartEvent` and `ToolCallEndEvent`: https://github.com/run-llama/llama_index/issues/16231

- validate that a call to query engine shows the same thread as we used to have (user message + RAG agent (retrieval + embedding + synthesise) + assistant message)
- validate that a call to `agent.chat` shows:

<img width="433" alt="image" src="https://github.com/user-attachments/assets/8878fec5-6962-4a0b-81af-11ea843d9a13">

Again, tool calls don't show. However, in the specific case of agents, LlamaIndex fires a `AgentToolCallEvent` prior to calling the tool. It's not enough to create a full tool step, and I decided it was best to let users decorate their own FunctionTool if they needed logs at that level. 

There is an option to refactor the span handler logic to catch the FunctionTool spans that are fired. There are a couple issues related to duplicate firing (nested) and a small revamp of the logic to allow the span handler to open/end steps. 