### PR TITLE
feat: expose label to create scores API

### DIFF
--- a/literalai/api/score_helpers.py
+++ b/literalai/api/score_helpers.py
@@ -71,6 +71,7 @@ def create_scores_fields_builder(scores: List[ScoreDict]):
         generated += f"""$name_{id}: String!
         $type_{id}: ScoreType!
         $value_{id}: Float!
+        $label_{id}: String
         $stepId_{id}: String
         $datasetExperimentItemId_{id}: String
         $scorer_{id}: String
@@ -88,6 +89,7 @@ def create_scores_args_builder(scores: List[ScoreDict]):
                 name: $name_{id}
                 type: $type_{id}
                 value: $value_{id}
+                label: $label_{id}
                 stepId: $stepId_{id}
                 datasetExperimentItemId: $datasetExperimentItemId_{id}
                 scorer: $scorer_{id}
@@ -98,6 +100,7 @@ def create_scores_args_builder(scores: List[ScoreDict]):
                 name
                 type
                 value
+                label
                 comment
                 scorer
             }}

--- a/literalai/observability/step.py
+++ b/literalai/observability/step.py
@@ -48,6 +48,7 @@ class ScoreDict(TypedDict, total=False):
     name: str
     type: ScoreType
     value: float
+    label: Optional[str]
     stepId: Optional[str]
     datasetExperimentItemId: Optional[str]
     comment: Optional[str]


### PR DESCRIPTION
### Changes:
- expose `label` to `create_scores` API

### To test:
- create an experiment from Python:
```
experiment = dataset.create_experiment(
    name="Next 1",
    params=[{ "type": "Mon expérience", "top_k": 2 }]
)

for index in range(2):
    scores = [{ 
        "name": "Sentiment",
        "type": "AI",
        "label": f"happy-{index}", # HERE IS THE LINE TO ADD COMPARED TO CLASSIC EXPERIMENT
        "value": 55
    }]

    experiment_item = {
        "datasetItemId": # Put the ID of a dataset item
        "scores": scores,
        "input": { "question": "kesako?" },
        "output": { "contexts": ["rien"] }
    }
    
    experiment.log(experiment_item)
```

If you have a platform version greater or equal to `0.0.627-beta`, you should see the label instead of the score value in the experiment details:
<img width="1445" alt="image" src="https://github.com/user-attachments/assets/ca4c13cf-79ea-48b0-9fb0-b2cbd87a7292">
