### PR TITLE
feat: add code score type

### DIFF
--- a/literalai/observability/step.py
+++ b/literalai/observability/step.py
@@ -40,7 +40,7 @@ MessageStepType = Literal["user_message", "assistant_message", "system_message"]
 StepType = Union[TrueStepType, MessageStepType]
 
 
-ScoreType = Literal["HUMAN", "AI"]
+ScoreType = Literal["HUMAN", "CODE", "AI"]
 
 
 class ScoreDict(TypedDict, total=False):


### PR DESCRIPTION
Expose `ScoreType.CODE`.

To be tested with platform containing [this PR](https://github.com/Chainlit/chainlit-cloud/pull/1128).
