### PR TITLE
fix: set settings.model to stream chunk model in openai instrumentation

### DIFF
--- a/literalai/instrumentation/openai.py
+++ b/literalai/instrumentation/openai.py
@@ -352,7 +352,6 @@ def instrument_openai(client: "LiteralClient", on_new_generation=None):
             if not generation:
                 return result
 
-            print(result)
             if model := getattr(result, "model", None):
                 generation.model = model
                 if generation.settings:

--- a/literalai/instrumentation/openai.py
+++ b/literalai/instrumentation/openai.py
@@ -310,6 +310,8 @@ def instrument_openai(client: "LiteralClient", on_new_generation=None):
                 and generation.model != chunk.model
             ):
                 generation.model = chunk.model
+                if generation.settings:
+                    generation.settings["model"] = chunk.model
 
             yield chunk
 
@@ -350,6 +352,7 @@ def instrument_openai(client: "LiteralClient", on_new_generation=None):
             if not generation:
                 return result
 
+            print(result)
             if model := getattr(result, "model", None):
                 generation.model = model
                 if generation.settings:


### PR DESCRIPTION
### Changes:
- in OpenAI instrumentation when streaming, set `settings.model` to model value given by stream chunk

### To test:
- Instrument OpenAI with client: `literalai_client.instrument_openai()`
- run an OpenAI chat completions call with `stream=True` and `model="gpt-4o-mini"`
- the Generation details page on platform should show the timestamped model like `gpt-4o-mini-2024-07-18`

Demo:
https://www.loom.com/share/2f359a2322764c65a555f66338e4f4e0