### PR TITLE
feat: add warning messages when getting deleted promp

### DIFF
--- a/literalai/api/helpers/gql.py
+++ b/literalai/api/helpers/gql.py
@@ -989,6 +989,7 @@ CREATE_PROMPT_LINEAGE = """mutation createPromptLineage(
     ) {
       id
       name
+      deletedAt
     }
   }"""
 
@@ -1024,6 +1025,7 @@ CREATE_PROMPT_VERSION = """mutation createPromptVersion(
       id
       lineage {
         name
+        deletedAt
       }
       version
       createdAt

--- a/literalai/api/helpers/gql.py
+++ b/literalai/api/helpers/gql.py
@@ -999,6 +999,7 @@ GET_PROMPT_LINEAGE = """query promptLineage(
         name: $name
     ) {
         id
+        deletedAt
     }
 }"""
 
@@ -1083,6 +1084,7 @@ query GetPrompt($id: String, $name: String, $version: Int) {
         version
         lineage {
             name
+            deletedAt
         }
     }
 }

--- a/literalai/api/helpers/prompt_helpers.py
+++ b/literalai/api/helpers/prompt_helpers.py
@@ -68,7 +68,7 @@ def create_prompt_helper(
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
             logger.warning(
-                f"Prompt {prompt_lineage.name} was deleted - please update any references to use an active prompt in production"
+                f"Prompt {prompt_lineage.get('name')} was deleted - please update any references to use an active prompt in production"
             )
         return Prompt.from_dict(api, prompt) if prompt else None
 

--- a/literalai/api/helpers/prompt_helpers.py
+++ b/literalai/api/helpers/prompt_helpers.py
@@ -22,7 +22,9 @@ def create_prompt_lineage_helper(name: str, description: Optional[str] = None):
     def process_response(response):
         prompt = response["data"]["createPromptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn(f"Prompt lineage {name} was deleted")
+            logger.warn(
+                f"Prompt {name} was deleted - please update any references to use an active prompt in production"
+            )
         return prompt
 
     description = "create prompt lineage"
@@ -36,7 +38,9 @@ def get_prompt_lineage_helper(name: str):
     def process_response(response):
         prompt = response["data"]["promptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn(f"Prompt lineage {name} was deleted")
+            logger.warn(
+                f"Prompt {name} was deleted - please update any references to use an active prompt in production"
+            )
         return prompt
 
     description = "get prompt lineage"
@@ -63,7 +67,9 @@ def create_prompt_helper(
         prompt_lineage = prompt.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn(f"Prompt version is part of a deleted lineage {prompt_lineage.get('name')}")
+            logger.warn(
+                f"Prompt {name} was deleted - please update any references to use an active prompt in production"
+            )
         return Prompt.from_dict(api, prompt) if prompt else None
 
     description = "create prompt version"
@@ -105,7 +111,9 @@ def get_prompt_helper(
         prompt_lineage = prompt_version.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn(f"Prompt version is part of a deleted lineage {prompt_lineage.get('name')}")
+            logger.warn(
+                f"Prompt {name} was deleted - please update any references to use an active prompt in production"
+            )
         prompt = Prompt.from_dict(api, prompt_version) if prompt_version else None
         if cache and prompt:
             put_prompt(cache, prompt)

--- a/literalai/api/helpers/prompt_helpers.py
+++ b/literalai/api/helpers/prompt_helpers.py
@@ -22,7 +22,7 @@ def create_prompt_lineage_helper(name: str, description: Optional[str] = None):
     def process_response(response):
         prompt = response["data"]["createPromptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn("This prompt lineage is part of a deleted lineage")
+            logger.warn(f"Prompt lineage {name} was deleted")
         return prompt
 
     description = "create prompt lineage"
@@ -36,7 +36,7 @@ def get_prompt_lineage_helper(name: str):
     def process_response(response):
         prompt = response["data"]["promptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn("This prompt lineage is part of a deleted lineage")
+            logger.warn(f"Prompt lineage {name} was deleted")
         return prompt
 
     description = "get prompt lineage"
@@ -63,7 +63,7 @@ def create_prompt_helper(
         prompt_lineage = prompt.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn("This prompt version is part of a deleted lineage")
+            logger.warn(f"Prompt version is part of a deleted lineage {prompt_lineage.get('name')}")
         return Prompt.from_dict(api, prompt) if prompt else None
 
     description = "create prompt version"
@@ -105,7 +105,7 @@ def get_prompt_helper(
         prompt_lineage = prompt_version.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn("This prompt version is part of a deleted lineage")
+            logger.warn(f"Prompt version is part of a deleted lineage {prompt_lineage.get('name')}")
         prompt = Prompt.from_dict(api, prompt_version) if prompt_version else None
         if cache and prompt:
             put_prompt(cache, prompt)

--- a/literalai/api/helpers/prompt_helpers.py
+++ b/literalai/api/helpers/prompt_helpers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict, Callable
+from typing import TYPE_CHECKING, Optional, TypedDict, Callable
 
 from literalai.observability.generation import GenerationMessage
 from literalai.prompt_engineering.prompt import Prompt, ProviderSettings

--- a/literalai/api/helpers/prompt_helpers.py
+++ b/literalai/api/helpers/prompt_helpers.py
@@ -22,7 +22,7 @@ def create_prompt_lineage_helper(name: str, description: Optional[str] = None):
     def process_response(response):
         prompt = response["data"]["createPromptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn(
+            logger.warning(
                 f"Prompt {name} was deleted - please update any references to use an active prompt in production"
             )
         return prompt
@@ -38,7 +38,7 @@ def get_prompt_lineage_helper(name: str):
     def process_response(response):
         prompt = response["data"]["promptLineage"]
         if prompt and prompt.get("deletedAt"):
-            logger.warn(
+            logger.warning(
                 f"Prompt {name} was deleted - please update any references to use an active prompt in production"
             )
         return prompt
@@ -67,8 +67,8 @@ def create_prompt_helper(
         prompt_lineage = prompt.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn(
-                f"Prompt {name} was deleted - please update any references to use an active prompt in production"
+            logger.warning(
+                f"Prompt {prompt_lineage.name} was deleted - please update any references to use an active prompt in production"
             )
         return Prompt.from_dict(api, prompt) if prompt else None
 
@@ -77,8 +77,10 @@ def create_prompt_helper(
     return gql.CREATE_PROMPT_VERSION, description, variables, process_response
 
 
-def get_prompt_cache_key(id: Optional[str], name: Optional[str], version: Optional[int]) -> str:
-    if id:  
+def get_prompt_cache_key(
+    id: Optional[str], name: Optional[str], version: Optional[int]
+) -> str:
+    if id:
         return id
     elif name and version:
         return f"{name}-{version}"
@@ -111,7 +113,7 @@ def get_prompt_helper(
         prompt_lineage = prompt_version.get("lineage")
 
         if prompt_lineage and prompt_lineage.get("deletedAt"):
-            logger.warn(
+            logger.warning(
                 f"Prompt {name} was deleted - please update any references to use an active prompt in production"
             )
         prompt = Prompt.from_dict(api, prompt_version) if prompt_version else None
@@ -121,7 +123,14 @@ def get_prompt_helper(
 
     description = "get prompt"
 
-    return gql.GET_PROMPT_VERSION, description, variables, process_response, timeout, cached_prompt
+    return (
+        gql.GET_PROMPT_VERSION,
+        description,
+        variables,
+        process_response,
+        timeout,
+        cached_prompt,
+    )
 
 
 def create_prompt_variant_helper(


### PR DESCRIPTION
# To test

- get or create or get prompt version or prompt lineage where the prompt lineage has been `deleted` which means that the value of the field `deletedAt` is not null

after adding the dev version of the repo as a dependency you can use this code to test it

```python
from literalai import LiteralClient

literalai_client = LiteralClient(
    url="http://localhost:3000", api_key="my-initial-api-key"
)

def get_prompt():
    prompt = literalai_client.api.get_prompt(name="Default", version=2)
    prompt2 = literalai_client.api.get_or_create_prompt(
        name="Default", template_messages=[]
    )
    prompt_lineage = literalai_client.api.get_or_create_prompt_lineage(name="Default")
    print("prompt", prompt)
    print("prompt2", prompt2)
    print("prompt lineage", prompt_lineage)

if __name__ == "__main__":
    get_prompt()
```