### PR TITLE
Clement/eng 2181 otel exporter

### DIFF
--- a/examples/langchain_toolcall.py
+++ b/examples/langchain_toolcall.py
@@ -19,6 +19,7 @@ search = TavilySearchResults(max_results=2)
 tools = [search]
 
 lai_client = LiteralClient()
+lai_client.initialize()
 lai_prompt = lai_client.api.get_or_create_prompt(
     name="LC Agent",
     settings={
@@ -37,12 +38,12 @@ lai_prompt = lai_client.api.get_or_create_prompt(
         {"role": "assistant", "content": "{{agent_scratchpad}}"},
     ],
 )
-prompt = lai_prompt.to_langchain_chat_prompt_template()
+prompt = lai_prompt.to_langchain_chat_prompt_template(
+    additional_messages=[("placeholder", "{agent_scratchpad}")],
+)
 
 agent: BaseSingleActionAgent = create_tool_calling_agent(model, tools, prompt)  # type: ignore
 agent_executor = AgentExecutor(agent=agent, tools=tools)
-
-cb = lai_client.langchain_callback()
 
 # Replace with ainvoke for asynchronous execution.
 agent_executor.invoke(
@@ -56,5 +57,5 @@ agent_executor.invoke(
         ],
         "input": "whats the weather in sf?",
     },
-    config=RunnableConfig(callbacks=[cb], run_name="Weather SF"),
+    config=RunnableConfig(run_name="Weather SF"),
 )

--- a/examples/langchain_variable.py
+++ b/examples/langchain_variable.py
@@ -1,12 +1,13 @@
 from langchain.chat_models import init_chat_model
 from literalai import LiteralClient
-from langchain.schema.runnable.config import RunnableConfig
+
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
 lai = LiteralClient()
+lai.initialize()
 
 prompt = lai.api.get_or_create_prompt(
     name="user intent",
@@ -29,13 +30,14 @@ messages = prompt.to_langchain_chat_prompt_template()
 input_messages = messages.format_messages(
     user_message="The screen is cracked, there are scratches on the surface, and a component is missing."
 )
-cb = lai.langchain_callback()
 
 # Returns a langchain_openai.ChatOpenAI instance.
 gpt_4o = init_chat_model(  # type: ignore
     model_provider=prompt.provider,
     **prompt.settings,
 )
-print(gpt_4o.invoke(input_messages, config=RunnableConfig(callbacks=[cb])))
+
+lai.set_properties(prompt=prompt)
+print(gpt_4o.invoke(input_messages))
 
 lai.flush_and_stop()

--- a/examples/llamaindex_workflow.py
+++ b/examples/llamaindex_workflow.py
@@ -16,6 +16,9 @@ lai_client.initialize()
 class JokeEvent(Event):
     joke: str
 
+class RewriteJoke(Event): 
+    joke: str
+
 
 class JokeFlow(Workflow):
     llm = OpenAI()
@@ -29,7 +32,11 @@ class JokeFlow(Workflow):
         return JokeEvent(joke=str(response))
 
     @step()
-    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
+    async def return_joke(self, ev: JokeEvent) -> RewriteJoke:
+        return RewriteJoke(joke=ev.joke + "What is funny?")
+
+    @step()
+    async def critique_joke(self, ev: RewriteJoke) -> StopEvent:
         joke = ev.joke
 
         prompt = f"Give a thorough analysis and critique of the following joke: {joke}"

--- a/examples/llamaindex_workflow.py
+++ b/examples/llamaindex_workflow.py
@@ -1,0 +1,48 @@
+import asyncio
+from llama_index.core.workflow import (
+    Event,
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+from llama_index.llms.openai import OpenAI
+from literalai.client import LiteralClient
+
+lai_client = LiteralClient()
+lai_client.initialize()
+
+
+class JokeEvent(Event):
+    joke: str
+
+
+class JokeFlow(Workflow):
+    llm = OpenAI()
+
+    @step()
+    async def generate_joke(self, ev: StartEvent) -> JokeEvent:
+        topic = ev.topic
+
+        prompt = f"Write your best joke about {topic}."
+        response = await self.llm.acomplete(prompt)
+        return JokeEvent(joke=str(response))
+
+    @step()
+    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
+        joke = ev.joke
+
+        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
+        response = await self.llm.acomplete(prompt)
+        return StopEvent(result=str(response))
+
+
+@lai_client.thread(name="JokeFlow")
+async def main():
+    w = JokeFlow(timeout=60, verbose=False)
+    result = await w.run(topic="pirates")
+    print(str(result))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/multimodal.py
+++ b/examples/multimodal.py
@@ -1,0 +1,84 @@
+import base64
+import requests  # type: ignore
+import time
+
+from literalai import LiteralClient
+from openai import OpenAI
+
+from dotenv import load_dotenv
+
+from literalai.observability.step import ScoreDict
+
+load_dotenv()
+
+openai_client = OpenAI()
+
+literalai_client = LiteralClient()
+literalai_client.initialize()
+
+
+def encode_image(url):
+    return base64.b64encode(requests.get(url).content)
+
+
+@literalai_client.step(type="run")
+def generate_answer(user_query, image_url):
+    literalai_client.set_properties(
+        name="foobar",
+        metadata={"foo": "bar"},
+        tags=["foo", "bar"],
+    )
+    completion = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": user_query},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image_url},
+                    },
+                ],
+            },
+        ],
+        max_tokens=300,
+    )
+    return completion.choices[0].message.content
+
+
+def main():
+    with literalai_client.thread(name="Meal Analyzer") as thread:
+        welcome_message = (
+            "Welcome to the meal analyzer, please upload an image of your plate!"
+        )
+        literalai_client.message(
+            content=welcome_message, type="assistant_message", name="My Assistant"
+        )
+
+        user_query = "Is this a healthy meal?"
+        user_image = "https://www.eatthis.com/wp-content/uploads/sites/4/2021/05/healthy-plate.jpg"
+        user_step = literalai_client.message(
+            content=user_query, type="user_message", name="User"
+        )
+
+        time.sleep(1)  # to make sure the user step has arrived at Literal AI
+
+        literalai_client.api.create_attachment(
+            thread_id=thread.id,
+            step_id=user_step.id,
+            name="meal_image",
+            content=encode_image(user_image),
+        )
+
+        answer = generate_answer(user_query=user_query, image_url=user_image)
+        literalai_client.message(
+            content=answer, type="assistant_message", name="My Assistant"
+        )
+
+
+main()
+# Network requests by the SDK are performed asynchronously.
+# Invoke flush_and_stop() to guarantee the completion of all requests prior to the process termination.
+# WARNING: If you run a continuous server, you should not use this method.
+literalai_client.flush_and_stop()

--- a/examples/multimodal.py
+++ b/examples/multimodal.py
@@ -7,7 +7,6 @@ from openai import OpenAI
 
 from dotenv import load_dotenv
 
-from literalai.observability.step import ScoreDict
 
 load_dotenv()
 

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -12,7 +12,7 @@ client = OpenAI()
 
 
 sdk = LiteralClient(batch_size=2)
-sdk.instrument_openai()
+sdk.initialize()
 
 
 @sdk.thread

--- a/literalai/client.py
+++ b/literalai/client.py
@@ -131,7 +131,8 @@ class BaseLiteralClient:
     def initialize(self):
         with redirect_stdout(io.StringIO()):
             Traceloop.init(
-                exporter=LoggingSpanExporter(event_processor=self.event_processor)
+                disable_batch=True,
+                exporter=LoggingSpanExporter(event_processor=self.event_processor),
             )
 
     def langchain_callback(

--- a/literalai/client.py
+++ b/literalai/client.py
@@ -1,7 +1,10 @@
+import json
 import os
 from traceloop.sdk import Traceloop
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import deprecated
+import io
+from contextlib import redirect_stdout
 
 from literalai.api import AsyncLiteralAPI, LiteralAPI
 from literalai.callback.langchain_callback import get_langchain_callback
@@ -125,9 +128,11 @@ class BaseLiteralClient:
 
         instrument_llamaindex(self.to_sync())
 
-    @classmethod
-    def initialize(cls):
-        Traceloop.init(exporter=LoggingSpanExporter())
+    def initialize(self):
+        with redirect_stdout(io.StringIO()):
+            Traceloop.init(
+                exporter=LoggingSpanExporter(event_processor=self.event_processor)
+            )
 
     def langchain_callback(
         self,
@@ -361,6 +366,27 @@ class BaseLiteralClient:
         Gets the current root run from the context.
         """
         return active_root_run_var.get()
+
+    def set_properties(
+        self,
+        name: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        thread = active_thread_var.get()
+        root_run = active_root_run_var.get()
+        parent = active_steps_var.get()[-1] if active_steps_var.get() else None
+
+        Traceloop.set_association_properties(
+            {
+                "literal.thread_id": str(thread.id) if thread else "None",
+                "literal.parent_id": str(parent.id) if parent else "None",
+                "literal.root_run_id": str(root_run.id) if root_run else "None",
+                "literal.name": str(name) if name else "None",
+                "literal.tags": json.dumps(tags) if tags else "None",
+                "literal.metadata": json.dumps(metadata) if metadata else "None",
+            }
+        )
 
     def reset_context(self):
         """

--- a/literalai/client.py
+++ b/literalai/client.py
@@ -1,4 +1,5 @@
 import os
+from traceloop.sdk import Traceloop
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import deprecated
 
@@ -11,6 +12,7 @@ from literalai.evaluation.experiment_item_run import (
     experiment_item_run_decorator,
 )
 from literalai.event_processor import EventProcessor
+from literalai.exporter import LoggingSpanExporter
 from literalai.instrumentation.mistralai import instrument_mistralai
 from literalai.instrumentation.openai import instrument_openai
 from literalai.my_types import Environment
@@ -122,6 +124,10 @@ class BaseLiteralClient:
         from literalai.instrumentation.llamaindex import instrument_llamaindex
 
         instrument_llamaindex(self.to_sync())
+
+    @classmethod
+    def initialize(cls):
+        Traceloop.init(exporter=LoggingSpanExporter())
 
     def langchain_callback(
         self,

--- a/literalai/client.py
+++ b/literalai/client.py
@@ -29,6 +29,7 @@ from literalai.observability.step import (
     step_decorator,
 )
 from literalai.observability.thread import ThreadContextManager, thread_decorator
+from literalai.prompt_engineering.prompt import Prompt
 from literalai.requirements import check_all_requirements
 
 
@@ -373,6 +374,7 @@ class BaseLiteralClient:
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        prompt: Optional[Prompt] = None,
     ):
         thread = active_thread_var.get()
         root_run = active_root_run_var.get()
@@ -386,6 +388,7 @@ class BaseLiteralClient:
                 "literal.name": str(name) if name else "None",
                 "literal.tags": json.dumps(tags) if tags else "None",
                 "literal.metadata": json.dumps(metadata) if metadata else "None",
+                "literal.prompt": json.dumps(prompt.to_dict()) if prompt else "None",
             }
         )
 

--- a/literalai/client.py
+++ b/literalai/client.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Dict, List, Optional, Union
+from typing_extensions import deprecated
 
 from literalai.api import AsyncLiteralAPI, LiteralAPI
 from literalai.callback.langchain_callback import get_langchain_callback
@@ -92,18 +93,21 @@ class BaseLiteralClient:
         else:
             return self  # type: ignore
 
+    @deprecated("Use Literal.initialize instead")
     def instrument_openai(self):
         """
         Instruments the OpenAI SDK so that all LLM calls are logged to Literal AI.
         """
         instrument_openai(self.to_sync())
 
+    @deprecated("Use Literal.initialize instead")
     def instrument_mistralai(self):
         """
         Instruments the Mistral AI SDK so that all LLM calls are logged to Literal AI.
         """
         instrument_mistralai(self.to_sync())
 
+    @deprecated("Use Literal.initialize instead")
     def instrument_llamaindex(self):
         """
         Instruments the Llama Index framework so that all RAG & LLM calls are logged to Literal AI.

--- a/literalai/event_processor.py
+++ b/literalai/event_processor.py
@@ -98,6 +98,7 @@ class EventProcessor:
             self.processing_counter -= len(batch)
 
     def flush_and_stop(self):
+        time.sleep(4)
         self.stop_event.set()
         if not self.disabled:
             self.processing_thread.join()

--- a/literalai/event_processor.py
+++ b/literalai/event_processor.py
@@ -98,7 +98,6 @@ class EventProcessor:
             self.processing_counter -= len(batch)
 
     def flush_and_stop(self):
-        time.sleep(4)
         self.stop_event.set()
         if not self.disabled:
             self.processing_thread.join()

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import json
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from typing import Dict, List, Optional, Sequence, cast
+from typing import Dict, List, Optional, Sequence, Union, cast
 import logging
 
 
@@ -149,13 +149,13 @@ class LoggingSpanExporter(SpanExporter):
             "id": str(span.context.span_id) if span.context else None,
             "name": span_props.get("name", span.name),
             "type": "llm",
-            "metadata": self._extract_json(span_props.get("metadata", "{}")),
+            "metadata": self._extract_json(str(span_props.get("metadata", "{}"))),
             "startTime": start_time,
             "endTime": end_time,
             "threadId": span_props.get("thread_id"),
             "parentId": span_props.get("parent_id"),
             "rootRunId": span_props.get("root_run_id"),
-            "tags": self._extract_json(span_props.get("tags", "[]")),
+            "tags": self._extract_json(str(span_props.get("tags", "[]"))),
             "input": {
                 "content": (
                     generation_content["messages"]
@@ -218,7 +218,7 @@ class LoggingSpanExporter(SpanExporter):
 
         return messages
 
-    def _extract_json(self, data: str) -> Dict | List | str:
+    def _extract_json(self, data: str) -> Union[Dict, List, str]:
         try:
             content = json.loads(data)
         except Exception:

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -1,6 +1,5 @@
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 import json
-from annotated_types import Timezone
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from typing import Dict, List, Optional, Sequence, cast

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -5,10 +5,11 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from typing import Dict, List, Optional, Sequence, cast
 import logging
 
+
 from literalai.event_processor import EventProcessor
 from literalai.helper import utc_now
 from literalai.observability.generation import GenerationType
-from literalai.observability.step import Step
+from literalai.observability.step import Step, StepDict
 
 
 class LoggingSpanExporter(SpanExporter):
@@ -39,8 +40,7 @@ class LoggingSpanExporter(SpanExporter):
                     and self.event_processor is not None
                 ):
                     step = self._create_step_from_span(span)
-                    self.event_processor.add_event(step.to_dict())
-                    self.logger.info(f"Created step from span: {step.to_dict()}")
+                    self.event_processor.add_event(cast(StepDict, step.to_dict()))
 
             return SpanExportResult.SUCCESS
         except Exception as e:
@@ -49,14 +49,25 @@ class LoggingSpanExporter(SpanExporter):
 
     def shutdown(self):
         """Shuts down the exporter."""
-        pass
+        if self.event_processor is not None:
+            return self.event_processor.flush_and_stop()
 
     def force_flush(self, timeout_millis: float = 30000) -> bool:
         """Force flush the exporter."""
         return True
 
+    #     # TODO: Add generation promptid
+    #     # TODO: Add generation variables
+    #     # TODO: Check missing variables
+    #     # TODO: ttFirstToken
+    #     # TODO: duration
+    #     # TODO: tokenThroughputInSeconds
+    #     # TODO: Add tools
+    #     # TODO: error check with gemini error
     def _create_step_from_span(self, span: ReadableSpan) -> Step:
         """Convert a span to a Step object"""
+        attributes = span.attributes or {}
+
         start_time = (
             datetime.fromtimestamp(span.start_time / 1e9, tz=timezone.utc).isoformat()
             if span.start_time
@@ -68,233 +79,100 @@ class LoggingSpanExporter(SpanExporter):
             else utc_now()
         )
 
-        self.logger.info(span.attributes)
-        parent_id = None
-        thread_id = None
-        root_run_id = None
-        metadata = None
-        name = None
-        tags = None
-        generation_messages = None
-        generation_message_completion = None
-        generation_prompt = None
-        generation_completion = None
-        generation_type = None
-        generation_model = None
-        generation_provider = None
-        generation_max_tokens = None
-        generation_stream = None
-        generation_token_count = None
-        generation_input_token_count = None
-        generation_output_token_count = None
-        generation_frequency_penalty = None
-        generation_logit_bias = None
-        generation_logprobs = None
-        generation_top_logprobs = None
-        generation_n = None
-        generation_presence_penalty = None
-        generation_response_format = None
-        generation_seed = None
-        generation_stop = None
-        generation_temperature = None
-        generation_top_p = None
-        generation_tool_choice = None
+        generation_type = attributes.get("llm.request.type")
+        is_chat = generation_type == "chat"
 
-        if span.attributes is not None:
-            self.logger.info(span.attributes)
-            parent_id = (
-                span.attributes.get(
-                    "traceloop.association.properties.literal.parent_id"
-                )
-                if span.attributes.get(
-                    "traceloop.association.properties.literal.parent_id"
-                )
-                and span.attributes.get(
-                    "traceloop.association.properties.literal.parent_id"
-                )
-                != "None"
-                else None
-            )
-            thread_id = (
-                span.attributes.get(
-                    "traceloop.association.properties.literal.thread_id"
-                )
-                if span.attributes.get(
-                    "traceloop.association.properties.literal.thread_id"
-                )
-                and span.attributes.get(
-                    "traceloop.association.properties.literal.thread_id"
-                )
-                != "None"
-                else None
-            )
-            root_run_id = (
-                span.attributes.get(
-                    "traceloop.association.properties.literal.root_run_id"
-                )
-                if span.attributes.get(
-                    "traceloop.association.properties.literal.root_run_id"
-                )
-                and span.attributes.get(
-                    "traceloop.association.properties.literal.root_run_id"
-                )
-                != "None"
-                else None
-            )
-            metadata = (
-                self.extract_json(
-                    str(
-                        span.attributes.get(
-                            "traceloop.association.properties.literal.metadata"
-                        )
-                    )
-                )
-                if span.attributes.get(
-                    "traceloop.association.properties.literal.metadata"
-                )
-                and span.attributes.get(
-                    "traceloop.association.properties.literal.metadata"
-                )
-                != "None"
-                else None
-            )
-            tags = (
-                self.extract_json(
-                    str(
-                        span.attributes.get(
-                            "traceloop.association.properties.literal.tags"
-                        )
-                    )
-                )
-                if span.attributes.get("traceloop.association.properties.literal.tags")
-                and span.attributes.get("traceloop.association.properties.literal.tags")
-                != "None"
-                else None
-            )
-            name = (
-                span.attributes.get("traceloop.association.properties.literal.name")
-                if span.attributes.get("traceloop.association.properties.literal.name")
-                and span.attributes.get("traceloop.association.properties.literal.name")
-                != "None"
-                else None
-            )
-            generation_type = span.attributes.get("llm.request.type")
-            generation_messages = (
-                self.extract_messages(span.attributes)
-                if generation_type == "chat"
-                else None
-            )
-            generation_message_completion = (
-                self.extract_messages(span.attributes, "gen_ai.completion.")[0]
-                if generation_type == "chat"
-                else None
-            )
-            generation_prompt = span.attributes.get("gen_ai.prompt.0.user")
-            generation_completion = span.attributes.get("gen_ai.completion.0.content")
-            generation_model = span.attributes.get("gen_ai.request.model")
-            generation_provider = span.attributes.get("gen_ai.system")
-            generation_max_tokens = span.attributes.get("gen_ai.request.max_tokens")
-            generation_stream = span.attributes.get("llm.is_streaming")
-            generation_token_count = span.attributes.get("llm.usage.total_tokens")
-            generation_input_token_count = span.attributes.get(
-                "gen_ai.usage.prompt_tokens"
-            )
-            generation_output_token_count = span.attributes.get(
-                "gen_ai.usage.completion_tokens"
-            )
-            # TODO: Validate settings
-            generation_frequency_penalty = span.attributes.get(
-                "gen_ai.request.frequency_penalty"
-            )
-            generation_logit_bias = span.attributes.get("gen_ai.request.logit_bias")
-            generation_logprobs = span.attributes.get("gen_ai.request.logprobs")
-            generation_top_logprobs = span.attributes.get("gen_ai.request.top_logprobs")
-            generation_n = span.attributes.get("gen_ai.request.n")
-            generation_presence_penalty = span.attributes.get(
-                "gen_ai.request.presence_penalty"
-            )
-            generation_response_format = span.attributes.get(
-                "gen_ai.request.response_format"
-            )
-            generation_seed = span.attributes.get("gen_ai.request.seed")
-            generation_stop = span.attributes.get("gen_ai.request.stop")
-            generation_temperature = span.attributes.get("gen_ai.request.temperature")
-            generation_top_p = span.attributes.get("gen_ai.request.top_p")
-            generation_tool_choice = span.attributes.get("gen_ai.request.tool_choice")
+        span_props = {
+            "parent_id": attributes.get(
+                "traceloop.association.properties.literal.parent_id"
+            ),
+            "thread_id": attributes.get(
+                "traceloop.association.properties.literal.thread_id"
+            ),
+            "root_run_id": attributes.get(
+                "traceloop.association.properties.literal.root_run_id"
+            ),
+            "metadata": attributes.get(
+                "traceloop.association.properties.literal.metadata"
+            ),
+            "tags": attributes.get("traceloop.association.properties.literal.tags"),
+            "name": attributes.get("traceloop.association.properties.literal.name"),
+        }
 
-        step = Step.from_dict(
-            {
-                "id": (str(span.context.span_id) if span.context else None),
-                "name": str(name) if name else span.name,
-                "type": "llm",
-                "metadata": cast(Dict, metadata),
-                "startTime": start_time,
-                "endTime": end_time,
-                "threadId": str(thread_id) if thread_id else None,
-                "parentId": str(parent_id) if parent_id else None,
-                "rootRunId": str(root_run_id) if root_run_id else None,
-                "input": (
-                    {"content": generation_messages}
-                    if generation_type == "chat"
-                    else {"content": generation_prompt}
-                ),
-                "output": (
-                    {"content": generation_message_completion}
-                    if generation_type == "chat"
-                    else {"content": generation_completion}
-                ),
-                "tags": cast(List, tags),
-                "generation": {
-                    "prompt": (
-                        generation_prompt if generation_type == "completion" else None
-                    ),
-                    "completion": (
-                        generation_completion
-                        if generation_type == "completion"
-                        else None
-                    ),
-                    "type": (
-                        GenerationType.CHAT
-                        if generation_type == "chat"
-                        else GenerationType.COMPLETION
-                    ),
-                    "model": generation_model,
-                    "provider": generation_provider,
-                    "settings": {
-                        "max_tokens": generation_max_tokens,
-                        "frequency_penalty": generation_frequency_penalty,
-                        "logit_bias": generation_logit_bias,
-                        "logprobs": generation_logprobs,
-                        "top_logprobs": generation_top_logprobs,
-                        "n": generation_n,
-                        "presence_penalty": generation_presence_penalty,
-                        "response_format": generation_response_format,
-                        "seed": generation_seed,
-                        "stop": generation_stop,
-                        "temperature": generation_temperature,
-                        "top_p": generation_top_p,
-                        "tool_choice": generation_tool_choice,
-                        "stream": generation_stream,
-                    },
-                    "tokenCount": generation_token_count,
-                    "inputTokenCount": generation_input_token_count,
-                    "outputTokenCount": generation_output_token_count,
-                    "messages": generation_messages,
-                    "messageCompletion": generation_message_completion,
-                },
-            }
-        )
+        span_props = {
+            k: str(v) for k, v in span_props.items() if v is not None and v != "None"
+        }
+
+        generation_content = {
+            "messages": (
+                self.extract_messages(cast(Dict, attributes)) if is_chat else None
+            ),
+            "message_completion": (
+                self.extract_messages(cast(Dict, attributes), "gen_ai.completion.")[0]
+                if is_chat
+                else None
+            ),
+            "prompt": attributes.get("gen_ai.prompt.0.user"),
+            "completion": attributes.get("gen_ai.completion.0.content"),
+            "model": attributes.get("gen_ai.request.model"),
+            "provider": attributes.get("gen_ai.system"),
+        }
+        generation_settings = {
+            "max_tokens": attributes.get("gen_ai.request.max_tokens"),
+            "stream": attributes.get("llm.is_streaming"),
+            "token_count": attributes.get("llm.usage.total_tokens"),
+            "input_token_count": attributes.get("gen_ai.usage.prompt_tokens"),
+            "output_token_count": attributes.get("gen_ai.usage.completion_tokens"),
+            "frequency_penalty": attributes.get("gen_ai.request.frequency_penalty"),
+            "presence_penalty": attributes.get("gen_ai.request.presence_penalty"),
+            "temperature": attributes.get("gen_ai.request.temperature"),
+            "top_p": attributes.get("gen_ai.request.top_p"),
+        }
+
+        step_dict = {
+            "id": str(span.context.span_id) if span.context else None,
+            "name": span_props.get("name", span.name),
+            "type": "llm",
+            "metadata": self.extract_json(span_props.get("metadata", "{}")),
+            "startTime": start_time,
+            "endTime": end_time,
+            "threadId": span_props.get("thread_id"),
+            "parentId": span_props.get("parent_id"),
+            "rootRunId": span_props.get("root_run_id"),
+            "tags": self.extract_json(span_props.get("tags", "[]")),
+            "input": {
+                "content": (
+                    generation_content["messages"]
+                    if is_chat
+                    else generation_content["prompt"]
+                )
+            },
+            "output": {
+                "content": (
+                    generation_content["message_completion"]
+                    if is_chat
+                    else generation_content["completion"]
+                )
+            },
+            "generation": {
+                "type": GenerationType.CHAT if is_chat else GenerationType.COMPLETION,
+                "prompt": generation_content["prompt"] if not is_chat else None,
+                "completion": generation_content["completion"] if not is_chat else None,
+                "model": generation_content["model"],
+                "provider": generation_content["provider"],
+                "settings": generation_settings,
+                "tokenCount": generation_settings["token_count"],
+                "inputTokenCount": generation_settings["input_token_count"],
+                "outputTokenCount": generation_settings["output_token_count"],
+                "messages": generation_content["messages"],
+                "messageCompletion": generation_content["message_completion"],
+            },
+        }
+
+        step = Step.from_dict(cast(StepDict, step_dict))
 
         if not span.status.is_ok:
             step.error = span.status.description or "Unknown error"
-
-        # TODO: Add generation promptid
-        # TODO: Add generation variables
-        # TODO: ttFirstToken
-        # TODO: duration
-        # TODO: tokenThroughputInSeconds
-        # TODO: Add tools
-        # TODO: error check with gemini error
 
         return step
 

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -13,6 +13,8 @@ from literalai.observability.step import Step, StepDict
 from literalai.prompt_engineering.prompt import PromptDict
 
 
+# TODO: Suppport Gemini models https://github.com/traceloop/openllmetry/issues/2419
+# TODO: Support llamaindex workflow https://github.com/traceloop/openllmetry/pull/2421
 class LoggingSpanExporter(SpanExporter):
     def __init__(
         self,
@@ -57,8 +59,6 @@ class LoggingSpanExporter(SpanExporter):
         """Force flush the exporter."""
         return True
 
-    # TODO: error check with gemini error
-    # TODO: ttFirstToken
     def _create_step_from_span(self, span: ReadableSpan) -> Step:
         """Convert a span to a Step object"""
         attributes = span.attributes or {}

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from typing import Sequence
+import logging
+
+from literalai.helper import utc_now
+from literalai.observability.step import Step
+
+from literalai.context import active_root_run_var, active_steps_var, active_thread_var
+
+
+class LoggingSpanExporter(SpanExporter):
+    def __init__(self, logger_name: str = "span_exporter"):
+        self.logger = logging.getLogger(logger_name)
+        self.logger.setLevel(logging.INFO)
+
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        """Export the spans by logging them."""
+        try:
+            for span in spans:
+                if (
+                    span.attributes
+                    and span.attributes.get("llm.is_streaming", None) is not None
+                ):
+                    step = self._create_step_from_span(span)
+                    self.logger.info(f"Created step from span: {step.to_dict()}")
+
+            return SpanExportResult.SUCCESS
+        except Exception as e:
+            self.logger.error(f"Failed to export spans: {e}")
+            return SpanExportResult.FAILURE
+
+    def shutdown(self):
+        """Shuts down the exporter."""
+        pass
+
+    def force_flush(self, timeout_millis: float = 30000) -> bool:
+        """Force flush the exporter."""
+        return True
+
+    def _create_step_from_span(self, span: ReadableSpan) -> Step:
+        """Convert a span to a Step object"""
+        start_time = (
+            datetime.fromtimestamp(span.start_time / 1e9, tz=timezone.utc).isoformat()
+            if span.start_time
+            else utc_now()
+        )
+        end_time = (
+            datetime.fromtimestamp(span.end_time / 1e9, tz=timezone.utc).isoformat()
+            if span.end_time
+            else utc_now()
+        )
+
+        self.logger.info(span.attributes)
+        parent_id = span.attributes.get("literal.parent_id")
+        thread_id = span.attributes.get("literal.thread_id")
+        root_run_id = span.attributes.get("literal.root_run_id")
+
+        self.logger.info(
+            f"From span attributes - Parent ID: {parent_id}, Thread ID: {thread_id}, Root Run ID: {root_run_id}"
+        )
+
+        step = Step(
+            id=(str(span.context.span_id) if span.context else None),
+            name=span.name,
+            type="llm",
+            start_time=start_time,
+            end_time=end_time,
+            thread_id=thread_id,
+            parent_id=parent_id,
+            root_run_id=root_run_id,
+        )
+
+        if span.status.is_ok:
+            step.error = span.status.description or "Unknown error"
+
+        # Handle input/output/generation based on span attributes
+        # (We'll implement this in the next iteration)
+
+        return step

--- a/literalai/exporter.py
+++ b/literalai/exporter.py
@@ -1,19 +1,25 @@
 from datetime import datetime, timezone
+import json
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from typing import Sequence
+from typing import Dict, List, Optional, Sequence, cast
 import logging
 
+from literalai.event_processor import EventProcessor
 from literalai.helper import utc_now
+from literalai.observability.generation import GenerationType
 from literalai.observability.step import Step
-
-from literalai.context import active_root_run_var, active_steps_var, active_thread_var
 
 
 class LoggingSpanExporter(SpanExporter):
-    def __init__(self, logger_name: str = "span_exporter"):
+    def __init__(
+        self,
+        logger_name: str = "span_exporter",
+        event_processor: Optional[EventProcessor] = None,
+    ):
         self.logger = logging.getLogger(logger_name)
         self.logger.setLevel(logging.INFO)
+        self.event_processor = event_processor
 
         if not self.logger.handlers:
             handler = logging.StreamHandler()
@@ -29,9 +35,11 @@ class LoggingSpanExporter(SpanExporter):
             for span in spans:
                 if (
                     span.attributes
-                    and span.attributes.get("llm.is_streaming", None) is not None
+                    and span.attributes.get("gen_ai.request.model", None) is not None
+                    and self.event_processor is not None
                 ):
                     step = self._create_step_from_span(span)
+                    self.event_processor.add_event(step.to_dict())
                     self.logger.info(f"Created step from span: {step.to_dict()}")
 
             return SpanExportResult.SUCCESS
@@ -61,29 +69,263 @@ class LoggingSpanExporter(SpanExporter):
         )
 
         self.logger.info(span.attributes)
-        parent_id = span.attributes.get("literal.parent_id")
-        thread_id = span.attributes.get("literal.thread_id")
-        root_run_id = span.attributes.get("literal.root_run_id")
+        parent_id = None
+        thread_id = None
+        root_run_id = None
+        metadata = None
+        name = None
+        tags = None
+        generation_messages = None
+        generation_message_completion = None
+        generation_prompt = None
+        generation_completion = None
+        generation_type = None
+        generation_model = None
+        generation_provider = None
+        generation_max_tokens = None
+        generation_stream = None
+        generation_token_count = None
+        generation_input_token_count = None
+        generation_output_token_count = None
+        generation_frequency_penalty = None
+        generation_logit_bias = None
+        generation_logprobs = None
+        generation_top_logprobs = None
+        generation_n = None
+        generation_presence_penalty = None
+        generation_response_format = None
+        generation_seed = None
+        generation_stop = None
+        generation_temperature = None
+        generation_top_p = None
+        generation_tool_choice = None
 
-        self.logger.info(
-            f"From span attributes - Parent ID: {parent_id}, Thread ID: {thread_id}, Root Run ID: {root_run_id}"
+        if span.attributes is not None:
+            self.logger.info(span.attributes)
+            parent_id = (
+                span.attributes.get(
+                    "traceloop.association.properties.literal.parent_id"
+                )
+                if span.attributes.get(
+                    "traceloop.association.properties.literal.parent_id"
+                )
+                and span.attributes.get(
+                    "traceloop.association.properties.literal.parent_id"
+                )
+                != "None"
+                else None
+            )
+            thread_id = (
+                span.attributes.get(
+                    "traceloop.association.properties.literal.thread_id"
+                )
+                if span.attributes.get(
+                    "traceloop.association.properties.literal.thread_id"
+                )
+                and span.attributes.get(
+                    "traceloop.association.properties.literal.thread_id"
+                )
+                != "None"
+                else None
+            )
+            root_run_id = (
+                span.attributes.get(
+                    "traceloop.association.properties.literal.root_run_id"
+                )
+                if span.attributes.get(
+                    "traceloop.association.properties.literal.root_run_id"
+                )
+                and span.attributes.get(
+                    "traceloop.association.properties.literal.root_run_id"
+                )
+                != "None"
+                else None
+            )
+            metadata = (
+                self.extract_json(
+                    str(
+                        span.attributes.get(
+                            "traceloop.association.properties.literal.metadata"
+                        )
+                    )
+                )
+                if span.attributes.get(
+                    "traceloop.association.properties.literal.metadata"
+                )
+                and span.attributes.get(
+                    "traceloop.association.properties.literal.metadata"
+                )
+                != "None"
+                else None
+            )
+            tags = (
+                self.extract_json(
+                    str(
+                        span.attributes.get(
+                            "traceloop.association.properties.literal.tags"
+                        )
+                    )
+                )
+                if span.attributes.get("traceloop.association.properties.literal.tags")
+                and span.attributes.get("traceloop.association.properties.literal.tags")
+                != "None"
+                else None
+            )
+            name = (
+                span.attributes.get("traceloop.association.properties.literal.name")
+                if span.attributes.get("traceloop.association.properties.literal.name")
+                and span.attributes.get("traceloop.association.properties.literal.name")
+                != "None"
+                else None
+            )
+            generation_type = span.attributes.get("llm.request.type")
+            generation_messages = (
+                self.extract_messages(span.attributes)
+                if generation_type == "chat"
+                else None
+            )
+            generation_message_completion = (
+                self.extract_messages(span.attributes, "gen_ai.completion.")[0]
+                if generation_type == "chat"
+                else None
+            )
+            generation_prompt = span.attributes.get("gen_ai.prompt.0.user")
+            generation_completion = span.attributes.get("gen_ai.completion.0.content")
+            generation_model = span.attributes.get("gen_ai.request.model")
+            generation_provider = span.attributes.get("gen_ai.system")
+            generation_max_tokens = span.attributes.get("gen_ai.request.max_tokens")
+            generation_stream = span.attributes.get("llm.is_streaming")
+            generation_token_count = span.attributes.get("llm.usage.total_tokens")
+            generation_input_token_count = span.attributes.get(
+                "gen_ai.usage.prompt_tokens"
+            )
+            generation_output_token_count = span.attributes.get(
+                "gen_ai.usage.completion_tokens"
+            )
+            # TODO: Validate settings
+            generation_frequency_penalty = span.attributes.get(
+                "gen_ai.request.frequency_penalty"
+            )
+            generation_logit_bias = span.attributes.get("gen_ai.request.logit_bias")
+            generation_logprobs = span.attributes.get("gen_ai.request.logprobs")
+            generation_top_logprobs = span.attributes.get("gen_ai.request.top_logprobs")
+            generation_n = span.attributes.get("gen_ai.request.n")
+            generation_presence_penalty = span.attributes.get(
+                "gen_ai.request.presence_penalty"
+            )
+            generation_response_format = span.attributes.get(
+                "gen_ai.request.response_format"
+            )
+            generation_seed = span.attributes.get("gen_ai.request.seed")
+            generation_stop = span.attributes.get("gen_ai.request.stop")
+            generation_temperature = span.attributes.get("gen_ai.request.temperature")
+            generation_top_p = span.attributes.get("gen_ai.request.top_p")
+            generation_tool_choice = span.attributes.get("gen_ai.request.tool_choice")
+
+        step = Step.from_dict(
+            {
+                "id": (str(span.context.span_id) if span.context else None),
+                "name": str(name) if name else span.name,
+                "type": "llm",
+                "metadata": cast(Dict, metadata),
+                "startTime": start_time,
+                "endTime": end_time,
+                "threadId": str(thread_id) if thread_id else None,
+                "parentId": str(parent_id) if parent_id else None,
+                "rootRunId": str(root_run_id) if root_run_id else None,
+                "input": (
+                    {"content": generation_messages}
+                    if generation_type == "chat"
+                    else {"content": generation_prompt}
+                ),
+                "output": (
+                    {"content": generation_message_completion}
+                    if generation_type == "chat"
+                    else {"content": generation_completion}
+                ),
+                "tags": cast(List, tags),
+                "generation": {
+                    "prompt": (
+                        generation_prompt if generation_type == "completion" else None
+                    ),
+                    "completion": (
+                        generation_completion
+                        if generation_type == "completion"
+                        else None
+                    ),
+                    "type": (
+                        GenerationType.CHAT
+                        if generation_type == "chat"
+                        else GenerationType.COMPLETION
+                    ),
+                    "model": generation_model,
+                    "provider": generation_provider,
+                    "settings": {
+                        "max_tokens": generation_max_tokens,
+                        "frequency_penalty": generation_frequency_penalty,
+                        "logit_bias": generation_logit_bias,
+                        "logprobs": generation_logprobs,
+                        "top_logprobs": generation_top_logprobs,
+                        "n": generation_n,
+                        "presence_penalty": generation_presence_penalty,
+                        "response_format": generation_response_format,
+                        "seed": generation_seed,
+                        "stop": generation_stop,
+                        "temperature": generation_temperature,
+                        "top_p": generation_top_p,
+                        "tool_choice": generation_tool_choice,
+                        "stream": generation_stream,
+                    },
+                    "tokenCount": generation_token_count,
+                    "inputTokenCount": generation_input_token_count,
+                    "outputTokenCount": generation_output_token_count,
+                    "messages": generation_messages,
+                    "messageCompletion": generation_message_completion,
+                },
+            }
         )
 
-        step = Step(
-            id=(str(span.context.span_id) if span.context else None),
-            name=span.name,
-            type="llm",
-            start_time=start_time,
-            end_time=end_time,
-            thread_id=thread_id,
-            parent_id=parent_id,
-            root_run_id=root_run_id,
-        )
-
-        if span.status.is_ok:
+        if not span.status.is_ok:
             step.error = span.status.description or "Unknown error"
 
-        # Handle input/output/generation based on span attributes
-        # (We'll implement this in the next iteration)
+        # TODO: Add generation promptid
+        # TODO: Add generation variables
+        # TODO: ttFirstToken
+        # TODO: duration
+        # TODO: tokenThroughputInSeconds
+        # TODO: Add tools
+        # TODO: error check with gemini error
 
         return step
+
+    def extract_messages(
+        self, data: Dict, prefix: str = "gen_ai.prompt."
+    ) -> List[Dict]:
+        messages = []
+        index = 0
+
+        while True:
+            role_key = f"{prefix}{index}.role"
+            content_key = f"{prefix}{index}.content"
+
+            if role_key not in data or content_key not in data:
+                break
+
+            messages.append(
+                {
+                    "role": data[role_key],
+                    "content": self.extract_json(data[content_key]),
+                }
+            )
+
+            index += 1
+
+        return messages
+
+    def extract_json(self, data: str) -> Dict | List | str:
+        try:
+            content = json.loads(data)
+        except Exception:
+            content = data
+
+        return content

--- a/literalai/instrumentation/openai.py
+++ b/literalai/instrumentation/openai.py
@@ -10,7 +10,12 @@ if TYPE_CHECKING:
 
 from literalai.context import active_steps_var, active_thread_var
 from literalai.helper import ensure_values_serializable
-from literalai.observability.generation import GenerationMessage, CompletionGeneration, ChatGeneration, GenerationType
+from literalai.observability.generation import (
+    GenerationMessage,
+    CompletionGeneration,
+    ChatGeneration,
+    GenerationType,
+)
 from literalai.wrappers import AfterContext, BeforeContext, wrap_all
 
 logger = logging.getLogger(__name__)

--- a/literalai/observability/thread.py
+++ b/literalai/observability/thread.py
@@ -5,6 +5,8 @@ import uuid
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypedDict
 
+from traceloop.sdk import Traceloop
+
 from literalai.context import active_thread_var
 from literalai.my_types import UserDict, Utils
 from literalai.observability.step import Step, StepDict
@@ -188,6 +190,11 @@ class ThreadContextManager:
     def __enter__(self) -> "Optional[Thread]":
         thread_id = self.thread_id if self.thread_id else str(uuid.uuid4())
         active_thread_var.set(Thread(id=thread_id, name=self.name, **self.kwargs))
+        Traceloop.set_association_properties(
+            {
+                "literal.thread_id": thread_id,
+            }
+        )
         return active_thread_var.get()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -198,6 +205,11 @@ class ThreadContextManager:
     async def __aenter__(self):
         thread_id = self.thread_id if self.thread_id else str(uuid.uuid4())
         active_thread_var.set(Thread(id=thread_id, name=self.name, **self.kwargs))
+        Traceloop.set_association_properties(
+            {
+                "literal.thread_id": thread_id,
+            }
+        )
         return active_thread_var.get()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,7 @@ ignore_missing_imports = True
 
 [mypy-traceloop.*]
 ignore_missing_imports = True
+
+[mypy-llama_index.*]
+ignore_missing_imports = True
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-langchain_community.*]
 ignore_missing_imports = True
+
+[mypy-traceloop.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ httpx>=0.23.0
 pydantic>=1,<3
 openai>=1.0.0
 chevron>=0.14.0
-traceloop-sdk>=0.33.9
+traceloop-sdk>=0.33.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ httpx>=0.23.0
 pydantic>=1,<3
 openai>=1.0.0
 chevron>=0.14.0
+traceloop-sdk>=0.33.9


### PR DESCRIPTION
## Changes

- Deprecate instrumentations call
- Added `initialize` method to the client
- Added a `set_properties` method for customization
- Added a custom Traceloop exporter to handle llm spans

## How to test?

### Test deprecations

- Test any examples that use an explicit instrumentation, notice the deprecation log

### Tests

- The basic streaming test `LITERAL_API_URL="http://localhost:3000" LITERAL_API_KEY="my-initial-api-key" python3 examples/streaming.py`

<img width="1127" alt="Screenshot 2024-12-16 at 17 45 55" src="https://github.com/user-attachments/assets/cdb2cfb2-6efb-4d51-8e68-ecaf42cab50e" />

- The langchain variables example `LITERAL_API_URL="http://localhost:3000" LITERAL_API_KEY="my-initial-api-key" python3 examples/langchain_variable.py`

<img width="1129" alt="Screenshot 2024-12-16 at 17 46 13" src="https://github.com/user-attachments/assets/c63acfec-0694-40b7-9965-de349a169b6e" />

- Test multimodal query `LITERAL_API_URL="http://localhost:3000" LITERAL_API_KEY="my-initial-api-key" python3 examples/multimodal.py`

<img width="1131" alt="Screenshot 2024-12-16 at 17 45 30" src="https://github.com/user-attachments/assets/a1e45098-ba20-444c-b82c-10992cadb487" />

- Test llamaindex flow `LITERAL_API_URL="http://localhost:3000" LITERAL_API_KEY="my-initial-api-key" python3 examples/llamaindex_workflow.py`

![Screenshot 2024-12-17 at 17 41 54](https://github.com/user-attachments/assets/07c5bfd7-53cd-4dbf-8a6b-ddd6ebf332fe)
