### PR TITLE
Fixing 'active_steps' getting mixed in async operations

### DIFF
--- a/literalai/client.py
+++ b/literalai/client.py
@@ -351,7 +351,7 @@ class BaseLiteralClient:
         """
         Gets the current step from the context.
         """
-        active_steps = active_steps_var.get()
+        active_steps = active_steps_var.get([])
         if active_steps and len(active_steps) > 0:
             return active_steps[-1]
         else:

--- a/literalai/context.py
+++ b/literalai/context.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from literalai.observability.step import Step
     from literalai.observability.thread import Thread
 
-active_steps_var = ContextVar[List["Step"]]("active_steps", default=[])
+active_steps_var = ContextVar[List["Step"]]("active_steps", default=None)
 active_thread_var = ContextVar[Optional["Thread"]]("active_thread", default=None)
 active_root_run_var = ContextVar[Optional["Step"]]("active_root_run_var", default=None)
 

--- a/literalai/instrumentation/mistralai.py
+++ b/literalai/instrumentation/mistralai.py
@@ -202,7 +202,7 @@ def instrument_mistralai(client: "LiteralClient", on_new_generation=None):
     def before_wrapper(metadata: Dict):
         def before(context: BeforeContext, *args, **kwargs):
             active_thread = active_thread_var.get()
-            active_steps = active_steps_var.get()
+            active_steps = active_steps_var.get([])
             generation = init_generation(metadata["type"], kwargs)
 
             if (active_thread or active_steps) and not callable(on_new_generation):
@@ -225,7 +225,7 @@ def instrument_mistralai(client: "LiteralClient", on_new_generation=None):
     def async_before_wrapper(metadata: Dict):
         async def before(context: BeforeContext, *args, **kwargs):
             active_thread = active_thread_var.get()
-            active_steps = active_steps_var.get()
+            active_steps = active_steps_var.get([])
             generation = init_generation(metadata["type"], kwargs)
 
             if (active_thread or active_steps) and not callable(on_new_generation):

--- a/literalai/instrumentation/openai.py
+++ b/literalai/instrumentation/openai.py
@@ -186,7 +186,7 @@ def instrument_openai(client: "LiteralClient", on_new_generation=None):
     def before_wrapper(metadata: Dict):
         def before(context: BeforeContext, *args, **kwargs):
             active_thread = active_thread_var.get()
-            active_steps = active_steps_var.get()
+            active_steps = active_steps_var.get([])
             generation = init_generation(metadata["type"], kwargs)
 
             if (active_thread or active_steps) and not callable(on_new_generation):
@@ -209,7 +209,7 @@ def instrument_openai(client: "LiteralClient", on_new_generation=None):
     def async_before_wrapper(metadata: Dict):
         async def before(context: BeforeContext, *args, **kwargs):
             active_thread = active_thread_var.get()
-            active_steps = active_steps_var.get()
+            active_steps = active_steps_var.get([])
             generation = init_generation(metadata["type"], kwargs)
 
             if (active_thread or active_steps) and not callable(on_new_generation):

--- a/literalai/observability/message.py
+++ b/literalai/observability/message.py
@@ -71,7 +71,7 @@ class Message(Utils):
         self.parent_id = parent_id
 
     def end(self):
-        active_steps = active_steps_var.get()
+        active_steps = active_steps_var.get([])
 
         if len(active_steps) > 0:
             parent_step = active_steps[-1]

--- a/literalai/observability/step.py
+++ b/literalai/observability/step.py
@@ -380,7 +380,7 @@ class Step(Utils):
             setattr(self, key, value)
 
     def start(self):
-        active_steps = active_steps_var.get()
+        active_steps = active_steps_var.get([])
         if len(active_steps) > 0:
             parent_step = active_steps[-1]
             if not self.parent_id:
@@ -405,7 +405,7 @@ class Step(Utils):
         self.end_time = utc_now()
 
         # Update active steps
-        active_steps = active_steps_var.get()
+        active_steps = active_steps_var.get([])
 
         # Check if step is active
         if self not in active_steps:

--- a/literalai/wrappers.py
+++ b/literalai/wrappers.py
@@ -53,7 +53,7 @@ def sync_wrapper(before_func=None, after_func=None):
             try:
                 result = original_func(*args, **kwargs)
             except Exception as e:
-                active_steps = active_steps_var.get()
+                active_steps = active_steps_var.get([])
                 if active_steps and len(active_steps) > 0:
                     current_step = active_steps[-1]
                     current_step.error = str(e)
@@ -87,7 +87,7 @@ def async_wrapper(before_func=None, after_func=None):
             try:
                 result = await original_func(*args, **kwargs)
             except Exception as e:
-                active_steps = active_steps_var.get()
+                active_steps = active_steps_var.get([])
                 if active_steps and len(active_steps) > 0:
                     current_step = active_steps[-1]
                     current_step.error = str(e)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -275,12 +275,12 @@ class Teste2e:
             with async_client.step(name="test_ingestion") as step:
                 step.metadata = {"foo": "bar"}
                 assert async_client.event_processor.event_queue._qsize() == 0
-                stack = active_steps_var.get()
+                stack = active_steps_var.get([])
                 assert len(stack) == 1
 
             assert async_client.event_processor.event_queue._qsize() == 1
 
-        stack = active_steps_var.get()
+        stack = active_steps_var.get([])
         assert len(stack) == 0
 
     @pytest.mark.timeout(5)


### PR DESCRIPTION
**Problem**
I noticed that some steps were being assigned to the wrong threads, as shown in the screenshot below. After investigating the implementation, I discovered that the `active_steps_var` ContextVar was sometimes being mixed during parallel executions.

<img width="738" alt="Screenshot 2025-01-22 at 13 31 51" src="https://github.com/user-attachments/assets/aa37d299-cb17-48eb-944e-3a6c0f6545e2" />

This issue seems similar to the [common Python gotcha](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments) where using mutable objects as default values can lead to unexpected behavior. Specifically, it's not safe to use mutable objects as the default value for ContextVars in the current implementation:

**Solution**
Use a non-mutable default value (such as None) for the ContextVar and provide an empty list when retrieving its value. This approach prevents the mixing of ContextVars during parallel executions.
```python
active_steps_var = ContextVar[List["Step"]]("active_steps", default=None)
active_steps_var.get([])  # Provide an empty list as the default value when getting the variable
````

**Code examples**
- [Current ContextVar implementation leading to incorrect results](https://ideone.com/P3vvvZ)
- [Fixed ContextVar implementation](https://ideone.com/9LVQrT)
- [Sample code using LiteralAI where the screenshot was obtained](https://ideone.com/xghhsb)