### PR TITLE
Allow step end_time overwrite

### DIFF
--- a/literalai/observability/step.py
+++ b/literalai/observability/step.py
@@ -402,7 +402,7 @@ class Step(Utils):
         active_steps_var.set(new_steps)
 
     def end(self):
-        self.end_time = utc_now()
+        self.end_time = utc_now() if self.end_time is None else self.end_time
 
         # Update active steps
         active_steps = active_steps_var.get()


### PR DESCRIPTION
### Minor fix: Preserve manually set `end_time` on `Step.end()`

#### Context  
When using the `with` syntax to log a step, we sometimes manually set `start_time` and `end_time` (e.g. to match historical timestamps or upsert an existing thread).  
However, the current implementation of `Step.end()` always overwrites `end_time` with `utc_now()`, which can lead to inaccurate timing data.

#### Change  
Updated the `end()` method to preserve the manually-set `end_time` if it already exists:

<pre lang="python">
self.end_time = utc_now() if self.end_time is None else self.end_time
</pre>

#### Example of `end_time` overwriting
<pre lang="python">
async with self.client.step(
    id=self.generate_uuid_v5_from_id(run.id),
    thread_id=self.generate_uuid_v5_from_id(thread_id),
    parent_id=self.generate_uuid_v5_from_id(parent_id),
    type="run",
    name=assistant_name,
) as step:
    step.created_at = created_at
    step.start_time = created_at
    step.end_time = completed_at
    step.input = input
    step.output = output
    step.generation = generation
</pre>

Now correctly logs `completed_at` instead of the current time.

#### Why it matters  
This ensures accurate time tracking when steps are being reconstructed or backfilled, and avoids unintentionally overwriting data.
