### PR TITLE
fix: pass variables to langchain messages on prompt rendering

### DIFF
--- a/literalai/prompt_engineering/prompt.py
+++ b/literalai/prompt_engineering/prompt.py
@@ -237,7 +237,7 @@ class Prompt(Utils):
                     except AttributeError:
                         for m in ChatPromptTemplate.from_messages(
                             [message]
-                        ).format_messages():
+                        ).format_messages(**kwargs):
                             rendered_messages.append(m)
                         continue
 


### PR DESCRIPTION
This PR fixes an issue when any additional messages passed to Literal AI prompt, converted using `to_langchain_chat_prompt_template` into LangChain prompt template will not receive variables

```python
client = AsyncLiteralClient()
prompt = client.get_prompt("prompt name")
prompt_template = prompt.to_langchain_chat_prompt_template([("placeholder", "{history}"), ("human", "{{query}}")])
llm = ChatOpenAI(**prompt.settings)
chain = prompt_template | llm | StrOutputParser()
runnable = RunnableWithMessageHistory(chain,
                                      get_session_history=get_session_history,
                                      input_messages_key="query",
                                      history_messages_key="history")

@chainlit.on_message
async def on_message(message: chainlit.Message):
  answer = chainlit.Message(content="")
  
  async for token in runnable.astream(
      {"query": query},
      config=RunnableConfig(callbacks=[chainlit.LangchainCallbackHandler()])
  ):
      await answer.stream_token(token)
  
  await answer.send()

```

`history` will not be rendered

P.S. This code looks very suspicious, I would say we should simply render with custom formatter first N messages which come from the prompt and then use default for the rest (additional) instead of catching exception, but this PR fixes an issue with minimal changes in code.