### PR TITLE
fix: resolve Python Datetime warnings

### DIFF
--- a/literalai/helper.py
+++ b/literalai/helper.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel
 
@@ -35,10 +35,10 @@ def force_dict(data, default_key="content"):
 
 
 def utc_now():
-    dt = datetime.utcnow()
+    dt = datetime.now(timezone.utc).replace(tzinfo=None)
     return dt.isoformat() + "Z"
 
 
 def timestamp_utc(timestamp: float):
-    dt = datetime.utcfromtimestamp(timestamp)
+    dt = datetime.fromtimestamp(timestamp, timezone.utc).replace(tzinfo=None)
     return dt.isoformat() + "Z"


### PR DESCRIPTION
## Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()

DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```
Note that `.replace(tzinfo=None)` allows to keep the original behavior where the time appears as a naive UTC timestamp (i.e., without any timezone offset).